### PR TITLE
Fix Windows CI

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,8 +12,9 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Install clang-format
+      shell: pwsh
       run: |
-        choco install llvm
+        choco install llvm -y
         refreshenv
 
     - name: Configure

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -15,7 +15,7 @@ jobs:
       shell: pwsh
       run: |
         choco install llvm -y
-        refreshenv
+        echo "::add-path::C:\\Program Files\\LLVM\\bin"
 
     - name: Configure
       run: cmake -Htest -Bbuild

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -12,7 +12,6 @@ jobs:
     - uses: actions/checkout@v1
 
     - name: Install clang-format
-      shell: pwsh
       run: |
         choco install llvm -y
         echo "::add-path::C:\\Program Files\\LLVM\\bin"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -23,10 +23,10 @@ jobs:
       run: "cmake --build build --target format"
 
     - name: Check format
-      run: "! cmake --build build --target check-format"
+      run: "!(cmake --build build --target check-format)"
 
     - name: Fix format
       run: cmake --build build --target fix-format
 
     - name: Check fixed format
-      run: cmake --build build --target check-format && ! git diff --exit-code
+      run: cmake --build build --target check-format && !(git diff --exit-code)


### PR DESCRIPTION
Based on the documentation I could find, the path [doesn't get propagated to further action steps](https://github.community/t5/GitHub-Actions/Append-PATH-on-Windows/m-p/31169/highlight/true#M694). Apparently the proper way to do this is use the `::add-path::` [command](https://help.github.com/en/actions/reference/workflow-commands-for-github-actions#adding-a-system-path) which I have never used. 