### PR TITLE
don't use executable suffix for find_program

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
 
-find_program(CLANG_FORMAT_PROGRAM clang-format${CMAKE_EXECUTABLE_SUFFIX})
+find_program(CLANG_FORMAT_PROGRAM clang-format)
 
 if (CLANG_FORMAT_PROGRAM)
   set(CLANG_FORMAT_COMMAND python ${CMAKE_CURRENT_LIST_DIR}/git-clang-format.py --binary=${CLANG_FORMAT_PROGRAM})


### PR DESCRIPTION
Using the executable suffix would break the format target when compiling for different platforms e.g. Windows or Wasm.