### PR TITLE
Disable formatting of CPM.cmake file

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Configure and build without format dependencies
       run: |
@@ -48,3 +48,14 @@ jobs:
 
     - name: Check fixed format
       run: cmake --build build --target check-format && ! git diff --exit-code
+
+    - name: Configure cmake-format with excluded file
+      run: |
+        git reset --hard HEAD
+        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\\.cmake$"
+
+    - name: Fix cmake-format skipping excluded file
+      run: cmake --build build --target fix-cmake-format
+
+    - name: Check cmake-format with excluded file
+      run: cmake --build build --target check-cmake-format && ! git diff --exit-code -- test/CMakeLists.txt && git diff --exit-code -- test/sample.cmake

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: windows-latest
 
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
 
     - name: Configure and build without format dependencies
       shell: bash
@@ -57,3 +57,17 @@ jobs:
     - name: Check fixed format
       shell: bash
       run: cmake --build build --target check-format && ! git diff --exit-code
+
+    - name: Configure cmake-format with excluded file
+      # Not using `bash` to prevent regular expression from being treated as a filesystem path
+      run: |
+        git reset --hard HEAD
+        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\.cmake$"
+
+    - name: Fix cmake-format skipping excluded file
+      shell: bash
+      run: cmake --build build --target fix-cmake-format
+
+    - name: Check cmake-format with excluded file
+      shell: bash
+      run: cmake --build build --target check-cmake-format && ! git diff --exit-code -- test/CMakeLists.txt && git diff --exit-code -- test/sample.cmake

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
 option(FORMAT_CHECK_CMAKE "Enable CMake formatting.")
+set(CMAKE_FORMAT_EXCLUDE "" CACHE STRING "CMake formatting file exclusion pattern.")
 
 find_program(CLANG_FORMAT_PROGRAM clang-format)
 find_program(GIT_PROGRAM git)
@@ -40,8 +41,9 @@ if (GIT_PROGRAM AND CMAKE_FORMAT_PROGRAM)
   function (add_cmake_format_target name)
     add_custom_target(${name}
       COMMAND ${CMAKE_COMMAND} -DGIT_PROGRAM=${GIT_PROGRAM} -DCMAKE_FORMAT_PROGRAM=${CMAKE_FORMAT_PROGRAM}
-        -DCMAKE_FORMAT_TARGET=${name} -DBINARY_DIR="${CMAKE_CURRENT_BINARY_DIR}"
-        -P ${CMAKE_CURRENT_LIST_DIR}/cmake-format.cmake
+        -DCMAKE_FORMAT_TARGET=${name} -DBINARY_DIR=${CMAKE_CURRENT_BINARY_DIR}
+        -DCMAKE_FORMAT_EXCLUDE=${CMAKE_FORMAT_EXCLUDE} -P ${CMAKE_CURRENT_LIST_DIR}/cmake-format.cmake
+      VERBATIM
       WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
     )
   endfunction()

--- a/cmake-format.cmake
+++ b/cmake-format.cmake
@@ -8,6 +8,10 @@ function (get_cmake_files)
   string(REPLACE "\n" ";" filtered_files "${all_files}")
   list(FILTER filtered_files
     INCLUDE REGEX ${_REGEX})
+  if (CMAKE_FORMAT_EXCLUDE)
+    list(FILTER filtered_files
+      EXCLUDE REGEX ${CMAKE_FORMAT_EXCLUDE})
+  endif()
   set(${_OUTPUT_LIST} ${filtered_files} PARENT_SCOPE)
 endfunction()
 


### PR DESCRIPTION
To better support the recommended method of adding and updating CPM.cmake, it might be helpful to disable that file from formatting.

In this pull request, formatting of CPM.cmake is skipped by default. The reasoning is that I don't know if adding a new option to the interface is acceptable or simplicity is preferable.

An alternative implementation would be to filter through Git's pathspec instead. Example:
```bash
${GIT_PROGRAM} ls-files --cached --exclude-standard ${_GIT_REPOSITORY_DIR} -- ':!:**/CPM.cmake'
```