### PR TITLE
always format cmake files

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -17,7 +17,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Install format dependencies
-      run: pip install cmake_format pyyaml
+      run: pip3 install cmake_format==0.6.11 pyyaml
 
     - name: Check source style
       run: cmake-format --check ./CMakeLists.txt ./cmake-format.cmake

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -18,7 +18,7 @@ jobs:
 
     - name: Configure and build without format dependencies
       run: |
-        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True
+        cmake -Htest -Bbuild
         cmake --build build
         ./build/test
         ! cmake --build build --target format
@@ -29,7 +29,7 @@ jobs:
         pip install cmake_format pyyaml
 
     - name: Configure
-      run: cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True
+      run: cmake -Htest -Bbuild
 
     - name: Run format
       run: "cmake --build build --target format"
@@ -52,7 +52,7 @@ jobs:
     - name: Configure cmake-format with excluded file
       run: |
         git reset --hard HEAD
-        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\\.cmake$"
+        cmake -Htest -Bbuild -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\\.cmake$"
 
     - name: Fix cmake-format skipping excluded file
       run: cmake --build build --target fix-cmake-format

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Install format dependencies
       run: |
         brew install clang-format
-        pip install cmake_format pyyaml
+        pip3 install cmake_format==0.6.11 pyyaml
 
     - name: Configure
       run: cmake -Htest -Bbuild

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Configure and build without format dependencies
       shell: bash
       run: |
-        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True
+        cmake -Htest -Bbuild
         cmake --build build
         ./build/Debug/test.exe
         ! cmake --build build --target format
@@ -32,7 +32,7 @@ jobs:
 
     - name: Configure
       shell: bash
-      run: cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True
+      run: cmake -Htest -Bbuild
 
     - name: Run format
       shell: bash
@@ -62,7 +62,7 @@ jobs:
       # Not using `bash` to prevent regular expression from being treated as a filesystem path
       run: |
         git reset --hard HEAD
-        cmake -Htest -Bbuild -DFORMAT_CHECK_CMAKE=True -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\.cmake$"
+        cmake -Htest -Bbuild -DCMAKE_FORMAT_EXCLUDE="(^|/)sample\.cmake$"
 
     - name: Fix cmake-format skipping excluded file
       shell: bash

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,6 +25,8 @@ jobs:
         ! cmake --build build --target format
 
     - name: Install format dependencies
+      env: 
+        ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
         choco install llvm -y
         echo "::add-path::C:\\Program Files\\LLVM\\bin"

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -28,7 +28,7 @@ jobs:
       run: |
         choco install llvm -y
         echo "::add-path::C:\\Program Files\\LLVM\\bin"
-        pip install cmake_format pyyaml
+        pip3 install cmake_format==0.6.11 pyyaml
 
     - name: Configure
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,5 @@
-option(FORMAT_CHECK_CMAKE "Enable CMake formatting.")
+option(FORMAT_SKIP_CMAKE "Skip CMake formatting.")
+
 set(CMAKE_FORMAT_EXCLUDE
     ""
     CACHE STRING "CMake formatting file exclusion pattern."
@@ -84,7 +85,7 @@ endif()
 list(APPEND FORMAT_TARGETS clang-format)
 list(APPEND CHECK_FORMAT_TARGETS check-clang-format)
 list(APPEND FIX_FORMAT_TARGETS fix-clang-format)
-if(FORMAT_CHECK_CMAKE)
+if(NOT FORMAT_SKIP_CMAKE)
   list(APPEND FORMAT_TARGETS cmake-format)
   list(APPEND CHECK_FORMAT_TARGETS check-cmake-format)
   list(APPEND FIX_FORMAT_TARGETS fix-cmake-format)

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Format.cmake adds three additional targets to your CMake project.
 
 To run the targets, invoke CMake with `cmake --build <build directory> --target <target name>`.
 
-To use _cmake_format_ to also format CMake files, enable the cmake option `FORMAT_CHECK_CMAKE`, e.g. by invoking CMake with `-DFORMAT_CHECK_CMAKE=ON`, or enabling the option when [adding the dependency](#how-to-integrate) (recommended).
+To disable using _cmake_format_ to format CMake files, set the cmake option `FORMAT_SKIP_CMAKE` to a truthy value, e.g. by invoking CMake with `-DFORMAT_SKIP_CMAKE=YES`, or enabling the option when [adding the dependency](#how-to-integrate) (recommended).
 
 ## Demo
 
@@ -39,10 +39,10 @@ include(cmake/CPM.cmake)
 
 CPMAddPackage(
   NAME Format.cmake
-  VERSION 1.6
+  VERSION 1.7.0
   GITHUB_REPOSITORY TheLartians/Format.cmake
-  OPTIONS # enable cmake formatting
-          "FORMAT_CHECK_CMAKE ON"
+  OPTIONS # set to yes skip cmake formatting
+          "FORMAT_SKIP_CMAKE NO"
           # skip scripts in the cmake directory
           "CMAKE_FORMAT_EXCLUDE (^|/)cmake"
 )

--- a/cmake-format.cmake
+++ b/cmake-format.cmake
@@ -12,7 +12,6 @@ function(get_cmake_files)
   if(CMAKE_FORMAT_EXCLUDE)
     list(FILTER filtered_files EXCLUDE REGEX ${CMAKE_FORMAT_EXCLUDE})
   endif()
-  message("filtered_files ${filtered_files}")
   set(${_OUTPUT_LIST}
       ${filtered_files}
       PARENT_SCOPE

--- a/cmake-format.cmake
+++ b/cmake-format.cmake
@@ -12,6 +12,7 @@ function(get_cmake_files)
   if(CMAKE_FORMAT_EXCLUDE)
     list(FILTER filtered_files EXCLUDE REGEX ${CMAKE_FORMAT_EXCLUDE})
   endif()
+  message("filtered_files ${filtered_files}")
   set(${_OUTPUT_LIST}
       ${filtered_files}
       PARENT_SCOPE


### PR DESCRIPTION
Now always formats CMakeFiles using cmake-format, unless the option `FORMAT_SKIP_CMAKE` is set.