### PR TITLE
Remove cached default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,5 @@
 option(FORMAT_SKIP_CMAKE "Skip CMake formatting.")
 
-set(CMAKE_FORMAT_EXCLUDE
-    ""
-    CACHE STRING "CMake formatting file exclusion pattern."
-)
-
 find_program(CLANG_FORMAT_PROGRAM clang-format)
 find_program(GIT_PROGRAM git)
 find_program(CMAKE_FORMAT_PROGRAM cmake-format)


### PR DESCRIPTION
Having a cached default prevents population of user-defined value on initial generation. The passed value to the underlying script is an empty string anyway.

Tracked down this issue due to failures in CI pipelines failing to exclude files because the regular expression gets passed as the empty string default value from the CMake cache on initial generation. Subsequent generations in the same area populated as expected.