### PR TITLE
Auto-install `cmake-format` if the program is not found

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -26,7 +26,6 @@ jobs:
     - name: Install format dependencies
       run: |
         brew install clang-format
-        pip3 install cmake_format==0.6.11 pyyaml
 
     - name: Configure
       run: cmake -Htest -Bbuild

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -25,12 +25,11 @@ jobs:
         ! cmake --build build --target format
 
     - name: Install format dependencies
-      env: 
+      env:
         ACTIONS_ALLOW_UNSECURE_COMMANDS: true
       run: |
         choco install llvm -y
         echo "::add-path::C:\\Program Files\\LLVM\\bin"
-        pip3 install cmake_format==0.6.11 pyyaml
 
     - name: Configure
       shell: bash

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ find_package(Python)
 
 if(NOT CMAKE_FORMAT_PROGRAM AND Python_FOUND)
   message(STATUS "Format.cmake: cmake-format not found, installing cmakelang")
-  execute_process(COMMAND ${Python_EXECUTABLE} -m pip install cmakelang)
+  execute_process(COMMAND ${Python_EXECUTABLE} -m pip install cmakelang==0.6.13 )
   find_program(CMAKE_FORMAT_PROGRAM cmake-format)
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,6 +5,12 @@ find_program(GIT_PROGRAM git)
 find_program(CMAKE_FORMAT_PROGRAM cmake-format)
 find_package(Python)
 
+if(NOT CMAKE_FORMAT_PROGRAM AND Python_FOUND)
+  message(STATUS "Format.cmake: cmake-format not found, installing cmakelang")
+  execute_process(COMMAND ${Python_EXECUTABLE} -m pip install cmakelang)
+  find_program(CMAKE_FORMAT_PROGRAM cmake-format)
+endif()
+
 if(CLANG_FORMAT_PROGRAM AND Python_FOUND)
   set(CLANG_FORMAT_COMMAND ${Python_EXECUTABLE} ${CMAKE_CURRENT_LIST_DIR}/git-clang-format.py
                            --binary=${CLANG_FORMAT_PROGRAM}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,27 @@ find_program(CMAKE_FORMAT_PROGRAM cmake-format)
 find_package(Python)
 
 if(NOT CMAKE_FORMAT_PROGRAM AND Python_FOUND)
-  message(STATUS "Format.cmake: cmake-format not found, installing cmakelang")
-  execute_process(COMMAND ${Python_EXECUTABLE} -m pip install cmakelang==0.6.13 )
-  find_program(CMAKE_FORMAT_PROGRAM cmake-format)
+  execute_process(
+    COMMAND ${Python_EXECUTABLE} -m venv ${CMAKE_BINARY_DIR}/_venv
+    RESULT_VARIABLE RES
+    OUTPUT_QUIET ERROR_QUIET
+  )
+  if(RES EQUAL 0)
+    if(EXISTS ${CMAKE_BINARY_DIR}/_venv/bin/cmake-format)
+      set(CMAKE_FORMAT_PROGRAM ${CMAKE_BINARY_DIR}/_venv/bin/cmake-format)
+    else()
+      message(STATUS "Format.cmake: cmake-format not found, installing cmakelang on the virtual environment")
+      execute_process(
+        COMMAND ${CMAKE_BINARY_DIR}/_venv/bin/pip install cmakelang==0.6.13
+        RESULT_VARIABLE RES
+      )
+      if(RES EQUAL 0)
+        set(CMAKE_FORMAT_PROGRAM ${CMAKE_BINARY_DIR}/_venv/bin/cmake-format)
+      else()
+        message(STATUS "Format.cmake: failed to install cmakelang on the virtual environment")
+      endif()
+    endif()
+  endif()
 endif()
 
 if(CLANG_FORMAT_PROGRAM AND Python_FOUND)


### PR DESCRIPTION
This pull request introduces the capability to automatically install `cmake-format` using `python -m pip` if the program is not found on the system. 

While it may be preferable to let users install their own `cmake-format` based on their preferences, this change proves useful in the context of GitHub Workflows. It simplifies the workflow by minimizing the need for explicit steps to install `cmake-format`, as the installation process is handled seamlessly by the script.