### PR TITLE
Add template implementation file endings

### DIFF
--- a/git-clang-format.py
+++ b/git-clang-format.py
@@ -79,7 +79,7 @@ def main():
       'c', 'h',  # C
       'm',  # ObjC
       'mm',  # ObjC++
-      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx',  # C++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc', 'inl',  # C++
       'cu',  # CUDA
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers


### PR DESCRIPTION
Thanks for this nice tool!

In tempalte heavy C++ code, the interface of a (member) function and its implementation are seperated in two files `.hh` and e.g. `.inl`. This is in contrast to having non-templated `.hh` and `.cpp` files.

This PR adds two common line endings for these files.