### PR TITLE
add new languages supported by llmv-18

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ After [adding CPM.cmake](https://github.com/cpm-cmake/CPM.cmake#adding-cpm), add
 
 ```cmake
 include(cmake/CPM.cmake)
-CPMAddPackage("gh:TheLartians/Format.cmake@1.7.3")
+CPMAddPackage("gh:TheLartians/Format.cmake@1.8.2")
 ```
 
 #### Advanced configuration
@@ -47,9 +47,9 @@ This package supports optional parameters that you can specify in the CPM.cmake 
 ```CMake
 CPMAddPackage(
   NAME Format.cmake
-  VERSION 1.7.3
+  VERSION 1.8.2
   GITHUB_REPOSITORY TheLartians/Format.cmake
-  OPTIONS 
+  OPTIONS
       # set to yes skip cmake formatting
       "FORMAT_SKIP_CMAKE NO"
       # set to yes skip clang formatting

--- a/cmake-format.cmake
+++ b/cmake-format.cmake
@@ -34,7 +34,7 @@ string(STRIP ${GIT_TOPLEVEL} GIT_TOPLEVEL)
 
 get_cmake_files(
   GIT_REPOSITORY_DIR ${GIT_TOPLEVEL} OUTPUT_LIST CMAKE_FILES REGEX
-  "\\.cmake$|(^|/)CMakeLists\\.txt$"
+  "\\.cmake$|\\.cmake\\.in$|(^|/)CMakeLists\\.txt$"
 )
 
 separate_arguments(CMAKE_FORMAT_EXTRA_ARGS)

--- a/git-clang-format.py
+++ b/git-clang-format.py
@@ -80,7 +80,7 @@ def main():
       'c', 'h',  # C
       'm',  # ObjC
       'mm',  # ObjC++
-      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc',  'inl',  # C++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc', 'inl',  # C++
       'ccm', 'cppm', 'cxxm', 'c++m',  # C++ Modules
       'cu', 'cuh',  # CUDA
       # Other languages that clang-format supports

--- a/git-clang-format.py
+++ b/git-clang-format.py
@@ -80,7 +80,7 @@ def main():
       'c', 'h',  # C
       'm',  # ObjC
       'mm',  # ObjC++
-      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc',  # C++
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc',  'inl',  # C++
       'ccm', 'cppm', 'cxxm', 'c++m',  # C++ Modules
       'cu', 'cuh',  # CUDA
       # Other languages that clang-format supports

--- a/git-clang-format.py
+++ b/git-clang-format.py
@@ -25,6 +25,7 @@ Requires Python 2.7 or Python 3
 """
 
 from __future__ import absolute_import, division, print_function
+
 import argparse
 import collections
 import contextlib
@@ -79,14 +80,17 @@ def main():
       'c', 'h',  # C
       'm',  # ObjC
       'mm',  # ObjC++
-      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc', 'inl',  # C++
-      'cu',  # CUDA
+      'cc', 'cp', 'cpp', 'c++', 'cxx', 'hh', 'hpp', 'hxx', 'inc',  # C++
+      'ccm', 'cppm', 'cxxm', 'c++m',  # C++ Modules
+      'cu', 'cuh',  # CUDA
       # Other languages that clang-format supports
       'proto', 'protodevel',  # Protocol Buffers
       'java',  # Java
       'js',  # JavaScript
       'ts',  # TypeScript
       'cs',  # C Sharp
+      'json',  # Json
+      'sv', 'svh', 'v', 'vh', # Verilog
       ])
 
   p = argparse.ArgumentParser(


### PR DESCRIPTION
And formated with: `isort --profile black .`

fixes for:
- https://github.com/TheLartians/Format.cmake/issues/40
- https://github.com/TheLartians/Format.cmake/issues/41