### PR TITLE
Update GitHub Actions to work on newer OS images

### DIFF
--- a/.github/workflows/style.yml
+++ b/.github/workflows/style.yml
@@ -8,16 +8,18 @@ on:
     branches:
       - master
 
+env:
+  CPM_SOURCE_CACHE: ${{ github.workspace }}/cpm_modules
+
 jobs:
   build:
-
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
-    - name: Install format dependencies
-      run: pip3 install cmake_format==0.6.11 pyyaml
+      - name: Install format dependencies
+        run: pip3 install cmake_format==0.6.11 pyyaml
 
-    - name: Check source style
-      run: cmake-format --check ./CMakeLists.txt ./cmake-format.cmake
+      - name: Check source style
+        run: cmake-format --check ./CMakeLists.txt ./cmake-format.cmake

--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   build:
 
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v2
@@ -25,8 +25,7 @@ jobs:
 
     - name: Install format dependencies
       run: |
-        brew install clang-format
-        pip3 install cmake_format==0.6.11 pyyaml
+        pip3 install clang-format==14.0.6 cmake_format==0.6.11 pyyaml
 
     - name: Configure
       run: cmake -Htest -Bbuild


### PR DESCRIPTION
This should fix the CI scripts which no longer seem to work on newer GitHub OS images.